### PR TITLE
Fix assorted conda envs

### DIFF
--- a/configs/amr.yaml
+++ b/configs/amr.yaml
@@ -1,6 +1,6 @@
 name: amrfinder
 channels:
+  - bioconda
   - conda-forge
-  - defaults
 dependencies:
   - ncbi-amrfinderplus = 4.0

--- a/configs/multiqc.yaml
+++ b/configs/multiqc.yaml
@@ -1,6 +1,6 @@
 name: multiqc
 channels:
-  - conda-forge
+  - bioconda
 dependencies:
   - multiqc = 1.30
 

--- a/configs/prokka.yaml
+++ b/configs/prokka.yaml
@@ -2,7 +2,6 @@ name: prokka
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - prokka = 1.14
   - blast = 2.12 


### PR DESCRIPTION
Several conda environments are either missing channels or contain unused channels. Missing channels have now been added and unused channels removed. 